### PR TITLE
Set identity on request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 
 # Don't accidentally commit local credentials
 .envrc
+tandem.toml

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 19.7.0
-postgres 15.1
-direnv 2.32.2
+nodejs   19.7.0
+postgres 15
+direnv   2.32.2

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: npm start
-worker: tandem
+tandem: tandem

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: npm start
+worker: tandem

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: npm start
+web: tandem npm start
 tandem: tandem

--- a/config/config.json
+++ b/config/config.json
@@ -16,11 +16,9 @@
     "timezone": "Australia/Sydney"
   },
   "production": {
-    "password": null,
-    "database": "sequelize-example",
-    "host": "127.0.0.1",
     "dialect": "postgres",
     "native": true,
-    "timezone": "Australia/Sydney"
+    "timezone": "Australia/Sydney",
+    "use_env_variable": "DATABASE_URL"
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,7 @@
 {
   "development": {
-    "password": null,
+    "user": "dan",
+    "password": "12qwaszx",
     "database": "sequelize-example",
     "host": "127.0.0.1",
     "dialect": "postgres",

--- a/models/index.js
+++ b/models/index.js
@@ -9,7 +9,7 @@ const env = process.env.NODE_ENV || 'development';
 const config = require(__dirname + '/../config/config.json')[env];
 const db = {};
 
-const setPort = (config) => !!process.env.STASH_DB_PORT ? { ...config, port: parseInt(process.env.STASH_DB_PORT, 10) } : config;
+const setPort = (config) => !!process.env.TANDEM_PORT ? { ...config, port: parseInt(process.env.TANDEM_PORT, 10) } : config;
 //const setPort = (config) => ({ ...config, port: parseInt(process.env.STASH_DB_PORT, 10) })
 
 let sequelize;

--- a/models/index.js
+++ b/models/index.js
@@ -9,12 +9,22 @@ const env = process.env.NODE_ENV || 'development';
 const config = require(__dirname + '/../config/config.json')[env];
 const db = {};
 
+const setPort = (config) => !!process.env.STASH_DB_PORT ? { ...config, port: parseInt(process.env.STASH_DB_PORT, 10) } : config;
+//const setPort = (config) => ({ ...config, port: parseInt(process.env.STASH_DB_PORT, 10) })
+
 let sequelize;
 if (config.use_env_variable) {
   sequelize = new Sequelize(process.env[config.use_env_variable], config);
 } else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
+  sequelize = new Sequelize(
+    process.env.STASH_DB_HOST || config.database,
+    config.username,
+    config.password,
+    setPort(config)
+  );
 }
+
+//console.debug(sequelize);
 
 fs
   .readdirSync(__dirname)

--- a/models/patient.js
+++ b/models/patient.js
@@ -21,6 +21,24 @@ module.exports = (sequelize, DataTypes) => {
     allergies: DataTypes.STRING,
     medications: DataTypes.STRING
   }, {
+    hooks: {
+      beforeFind: async (options) => {
+        console.error('beforeFind hook', options);
+        if (options.__identity) {
+          await sequelize.query(
+            // Uncomment this line when using with Proxy
+            '--SET IDENTITY TO ?', {
+              replacements: [options.__identity],
+            }
+          );
+          delete options.__identity;
+        }
+      },
+      beforeFindAfterOptions: (options) => {
+        // __identity is not present because it has been removed in the beforeFind hook
+        console.error('beforeFindAfterOptions hook', options);
+      },
+    },
     sequelize,
     modelName: 'patient',
   });

--- a/server.js
+++ b/server.js
@@ -74,7 +74,8 @@ app.get(
 
     const patients = await models.patient.findAll({
       order,
-      where
+      where,
+      __identity: "some-long-token" // Set the JWT here
     });
 
     res.status(200).json(patients);

--- a/tandem.toml
+++ b/tandem.toml
@@ -1,0 +1,1 @@
+log_level = "info"

--- a/tandem.toml
+++ b/tandem.toml
@@ -1,1 +1,0 @@
-log_level = "info"


### PR DESCRIPTION
* Sets the identity as an extra attribute to `findAll` (could be done using a decorator)
* Uses a query callback to set the context and strip out the extra information before processing